### PR TITLE
Fix table.clone() to make it runnable on Lua <5.3

### DIFF
--- a/src/helpFunctions.lua
+++ b/src/helpFunctions.lua
@@ -109,9 +109,12 @@ end
 
 -- ##### -- ##### -- ##### -- ##### -- ##### -- ##### -- ##### -- ##### -- ##### -- 
 
--- source: http://lua-users.org/wiki/CopyTable
 function table.clone(org)
-  return {table.unpack(org)}
+  local newTable = {}
+  for k,v in pairs(org) do
+      newTable[k] = v
+  end
+  return newTable
 end
 
 -- ##### -- ##### -- ##### -- ##### -- ##### -- ##### -- ##### -- ##### -- ##### -- 


### PR DESCRIPTION
`table.unpack` is only available for Lua 5.3+ so with his little hack you can run the entire code on Lua 5+ (including Lua 5.1 and LÖVE2D's LuaJIT)

Related to #1 